### PR TITLE
Remove unsupported configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,5 +23,3 @@ gitlab_runner_allowed_pull_policies:
 #   - gitlab_url: https://my.gitlab.url
 #     project: mygroup/my-project
 #     registration_token: mysecureprojecttoken
-#   - gitlab_url: https://my.gitlab.url
-#     registration_token: mysecureinstancetoken


### PR DESCRIPTION
The role requires either a group or a project for a runner.

Otherwise the role fails with:
```
fatal: [docker01]: FAILED! => {"msg": "
The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'project'

The error appears to be in '/home/me/.ansible/roles/lgatellier.gitlab_runner_compose/tasks/single-runner.yml': line 2, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

---
- name: Determine configuration for the runner
  ^ here
"}
```