### PR TITLE
fix: Ansible lint issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,2 @@
+warn_list:
+  - no-handler

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ gitlab_runner_concurrent_jobs: 5
 gitlab_runner_check_interval: 3
 gitlab_runner_session_timeout: 1800
 gitlab_runner_output_limit: 102400
-gitlab_runner_allowed_pull_policies: 
+gitlab_runner_allowed_pull_policies:
   - always
   - if-not-present
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 galaxy_info:
   role_name: gitlab_runner_compose
+  namespace: lgatellier
   author: Léo GATELLIER
   description: A role to setup a Docker Compose based GitLab Runner
 
@@ -16,7 +17,7 @@ galaxy_info:
   # - CC-BY-4.0
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: '2.9'
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -27,17 +28,13 @@ galaxy_info:
   # To view available platforms and versions (or releases), visit:
   # https://galaxy.ansible.com/api/v1/platforms/
   #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+  platforms:
+    - name: EL
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - all
 
   galaxy_tags: # Maximum 20 tags per role.
     - gitlab

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,4 +61,3 @@
     name: gitlab-runner.service
     enabled: true
     state: started
-


### PR DESCRIPTION
Fixes ansible lint issues.

Setting `no-handler` as warning, because using a handler and flushing it immediately would add useless complexity.